### PR TITLE
Fix appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,7 +54,6 @@ build_script:
   - mkdir web\upload\download
   - bin\nim c koch
   - koch boot -d:release
-  - koch docs
   - nim c tools\winrelease
   - tools\winrelease
   - cd ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,7 +58,7 @@ build_script:
   - nim c tools\winrelease
   - tools\winrelease
   - cd ..
-  - appveyor PushArtifact nim\web\upload\download\nim-*.zip
+  - ps: get-item .\nim\web\upload\download\nim-*.zip | % { Push-AppveyorArtifact $_.FullName }
 
 deploy:
   release: nim-appveyor # v$(appveyor_build_version)


### PR DESCRIPTION
1. https://github.com/nim-lang/nightlies/blob/d2bc2cd71894a860803fca8a775cb313bedb9963/appveyor.yml#L61 `appveyor` does not support wildcards, neither does windows cmd, so modified to use powershell.
2. Removed [`koch docs`](https://github.com/nim-lang/nightlies/blob/d2bc2cd71894a860803fca8a775cb313bedb9963/appveyor.yml#L57) as I don't think it was being used for anything and was only wasting time.