### PR TITLE
Fix windows build

### DIFF
--- a/nightlies.sh
+++ b/nightlies.sh
@@ -67,6 +67,7 @@ then
     wget -nv https://nim-lang.org/download/windeps.zip
     7z x -y "windeps.zip" -o"../bin" > nul
     rm -rf windeps.zip
+	  export PATH="../bin:${PATH}"
   else
     sh build.sh
   fi


### PR DESCRIPTION
Windows build is failing because the sqlite dlls are in bin folder, whereas koch boot builds nim in the compiler/ folder. So either the dlls need to be copied over there, or bin/ should be in path.
  
ping @narimiran @genotrance 
  
Refs https://forum.nim-lang.org/t/5105