### PR TITLE
Fix Windows Build

### DIFF
--- a/nightlies.sh
+++ b/nightlies.sh
@@ -66,6 +66,7 @@ then
     cmd "/C build.bat"
     wget -nv https://nim-lang.org/download/windeps.zip
     7z x -y "windeps.zip" -o"../bin" > nul
+    export PATH="$(realpath ../bin):${PATH}"
     rm -rf windeps.zip
   else
     sh build.sh


### PR DESCRIPTION
Windows build is failing because the sqlite dlls are in bin folder, whereas koch boot builds nim in the compiler/ folder. So either the dlls need to be copied over there, or bin/ should be in path.
  
ping @narimiran @genotrance 
  
Refs https://forum.nim-lang.org/t/5105