### PR TITLE
travis: fix warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: c
 services:
   - docker
 
-matrix:
+jobs:
   include:
   - os: linux
     env: NIMBRANCH=devel ARCH=64
@@ -92,16 +92,16 @@ before_deploy:
 
 deploy:
   provider: releases
-  api_key: "${GITHUB_OAUTH_TOKEN}"
+  token: "${GITHUB_OAUTH_TOKEN}"
   file: "${ASSETFILE}"
   name: "${TRAVIS_TAG} nightly build"
-  body: >-
+  release_notes: >-
     This nightly release was built on ${BUILD_DATE} using https://github.com/nim-lang/Nim/tree/${NIMVER}.
     The Windows and Linux archives contain pre-packaged source as well as platform specific binaries
     whereas the OSX archive contains pre-packaged source only. Any of these archives can be used to
     build Nim on Windows, Linux and OSX.
 
-  skip_cleanup: true
+  cleanup: false
   on:
     condition: "! -z ${DO_DEPLOY+x}"
     tags: false


### PR DESCRIPTION
Those warnings can be seen here: https://travis-ci.org/nim-lang/nightlies/builds/653761248/config

Not sure if this is the right way to correct *"`deploy`: deprecated key `skip_cleanup` (not supported in dpl v2, use cleanup)"*