### PR TITLE
workflows/nightlies: shiny new nightlies pipeline

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -1,0 +1,382 @@
+name: Nightlies
+on:
+  push:
+    branches:
+      - master
+      - actions
+  pull_request:
+    branches:
+      - '*'
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  setup:
+    name: 'build settings'
+    runs-on: ubuntu-latest
+    outputs:
+      settings: ${{ steps.settings.outputs.settings }}
+      deploy: ${{ steps.settings.outputs.deploy }}
+    steps:
+      - name: Checkout nightlies
+        uses: actions/checkout@v2
+        with:
+          path: nightlies
+
+      - name: Generate version matrix
+        shell: bash
+        run: |
+          # Tracked branches
+          branches=( 'devel' 'version-1-2' 'version-1-0' )
+
+          getHash() {
+            git ls-remote "https://github.com/$1" "$2" | cut -f 1
+          }
+
+          {
+            for branch in "${branches[@]}"; do
+              jq --null-input \
+                 --arg branch "$branch" \
+                 --arg commit "$(getHash nim-lang/Nim "$branch")" \
+                 '{ branch: $branch, commit: $commit }'
+            done
+          } | jq -s '.' | tee versions.json
+
+      - name: Restore build settings
+        uses: actions/cache@v2
+        with:
+          path: settings
+          key: build-settings-${{ hashFiles('versions.json') }}
+          restore-keys: build-settings-
+
+      - name: Generate build settings
+        id: settings
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          deploy=false
+          case '${{ github.event_name }}' in
+            schedule)
+              deploy=true
+              ;;
+            push)
+              message=$(
+                cd nightlies
+                git show -s --format=%s '${{ github.ref }}'
+              )
+
+              if [[ $message == *'[deploy]'* ]]; then
+                deploy=true
+              else
+                deploy=false
+              fi
+          esac
+
+          declare -A refs
+
+          while IFS='=' read -r branch commit; do
+            refs[$branch]=$commit
+          done <<< "$(jq -r '.[] | .branch + "=" + .commit' versions.json)"
+
+          mkdir -p settings
+          # Delete older branch settings (if they were restored)
+          find settings -mindepth 1 -maxdepth 1 $(printf "! -name %q.json " "${!refs[@]}")
+
+          declare -A environment=(
+            [SOURCE_CODE_EPOCH]=$(date -u +%s)
+          )
+
+          for branch in "${!refs[@]}"; do
+            savedCommit=
+            commit=${refs[$branch]}
+            if [[ -e "settings/$branch.json" ]]; then
+              savedCommit=$(jq -r '.commit' "settings/$branch.json")
+            fi
+            if [[ $savedCommit != "$commit" ]]; then
+              echo "::group::Generating build settings for branch $branch"
+              {
+                {
+                  for var in "${!environment[@]}"; do
+                    jq --null-input \
+                       --arg variable "$var" \
+                       --arg value "${environment[$var]}" \
+                       '{ ($variable): $value }'
+                  done
+                } | jq -s '{ environment: (reduce .[] as $item (null; . + $item)) }'
+
+                tag=$(date -u --date="@${environment[SOURCE_CODE_EPOCH]}" +%F)-$branch-$commit
+
+                jq --null-input --arg tag "$tag" '{ release: $tag }'
+
+              } | jq -s --arg commit "$commit" 'reduce .[] as $item ({ commit: $commit }; . + $item)' > "settings/$branch.json"
+            else
+              echo "::group::Stored settings for branch $branch @ $commit found."
+            fi
+            jq --arg branch "$branch" '.[] | select(.branch == $branch)' versions.json | jq -s 'add' - "settings/$branch.json" | tee -a settings.json
+            echo "::endgroup::"
+          done
+
+          echo "::set-output name=settings::$(jq -sc '.' settings.json)"
+          echo "::set-output name=deploy::$deploy"
+
+  sourceArchive:
+    needs: setup
+
+    strategy:
+      fail-fast: false
+      matrix:
+        setting: ${{ fromJson(needs.setup.outputs.settings) }}
+    name: 'source (${{ matrix.setting.branch }}, ${{ matrix.setting.commit }})'
+    runs-on: ubuntu-latest
+    env: ${{ matrix.setting.environment }}
+    steps:
+      - name: Checkout nightlies
+        uses: actions/checkout@v2
+        with:
+          path: nightlies
+
+      - name: Restore Nim from cache
+        id: nim-cache
+        uses: actions/cache@v2
+        with:
+          path: nim/output/nim-*.tar.xz
+          key: 'source-${{ matrix.setting.commit }}'
+
+      - name: Get latest csources version
+        if: steps.nim-cache.outputs.cache-hit != 'true'
+        id: csources-version
+        shell: bash
+        run: |
+          getHash() {
+            git ls-remote "https://github.com/$1" "$2" | cut -f 1
+          }
+
+          echo "::set-output name=commit::$(getHash nim-lang/csources master)"
+
+      - name: Restore csources from cache
+        if: steps.nim-cache.outputs.cache-hit != 'true'
+        id: csources-cache
+        uses: actions/cache@v1
+        with:
+          path: csources/bin
+          key: 'csources-${{ runner.os }}-${{ steps.csources-version.outputs.commit }}'
+
+      - name: Checkout Nim
+        if: steps.nim-cache.outputs.cache-hit != 'true'
+        uses: actions/checkout@v2
+        with:
+          repository: nim-lang/Nim
+          ref: ${{ matrix.setting.commit }}
+          path: nim
+
+      - name: Checkout csources
+        if: >
+          steps.nim-cache.outputs.cache-hit != 'true' &&
+          steps.csources-cache.outputs.cache-hit != 'true'
+        uses: actions/checkout@v2
+        with:
+          repository: nim-lang/csources
+          path: csources
+
+      - name: Setup environment
+        shell: bash
+        run: echo '::add-path::${{ github.workspace }}/nim/bin'
+
+      - name: Build 1-stage csources compiler
+        if: steps.nim-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          if [[ ! -e csources/bin/nim ]]; then
+            make -C csources -j $(nproc) CC=gcc
+          else
+            echo 'Using prebuilt csources'
+          fi
+          cp csources/bin/nim nim/bin
+
+      - name: Build compiler
+        if: steps.nim-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          cd nim
+          nim c koch
+          ./koch boot -d:release
+
+      - name: Generate csources
+        if: steps.nim-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          cd nim
+          ./koch csources -d:danger '-d:gitHash:${{ matrix.setting.commit }}'
+
+      - name: Build source archive
+        if: steps.nim-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          cd nim
+          ./koch xz
+
+          mkdir -p output
+          cp build/nim-*.tar.xz output
+
+      - name: Publish release
+        if: needs.setup.outputs.deploy == 'true'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if ! hub -C nightlies release show '${{ matrix.setting.release }}' >/dev/null 2>&1; then
+            cat << EOF | hub -C nightlies release create -a nim/output/nim-*.tar.xz -F - '${{ matrix.setting.release }}' >/dev/null
+          Nightly build on $(date -u --date="@$SOURCE_CODE_EPOCH" "+%F") for branch ${{ matrix.setting.branch }}
+
+          Commit: https://github.com/nim-lang/Nim/commit/${{ matrix.setting.commit }}
+
+          Generated release binaries will be uploaded as they're made available.
+          EOF
+          else
+            echo "Release '${{ matrix.setting.release }}' has already been created, skipping."
+          fi
+
+      - name: Upload source archive to artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: 'nim-${{ matrix.setting.commit }}'
+          path: nim/output/*
+
+  build:
+    needs: [ setup, sourceArchive ]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        setting: ${{ fromJson(needs.setup.outputs.settings) }}
+        target:
+          - os: linux
+            triple: x86_64-linux-musl
+          - os: linux
+            triple: i686-linux-musl
+          - os: linux
+            triple: aarch64-linux-musl
+          - os: linux
+            triple: armv7l-linux-musleabihf
+          - os: macosx
+            triple: x86_64-apple-darwin14
+          - os: windows
+            triple: x86_64-w64-mingw32
+          - os: windows
+            triple: i686-w64-mingw32
+        include:
+          - target:
+              os: linux
+            builder: ubuntu-18.04
+          - target:
+              os: macosx
+            builder: macos-10.15
+          - target:
+              os: windows
+            builder: windows-2019
+
+    env: ${{ matrix.setting.environment }}
+    name: '${{ matrix.target.triple }} (${{ matrix.setting.branch }}, ${{ matrix.setting.commit }})'
+    runs-on: ${{ matrix.builder }}
+    steps:
+      - name: Checkout build scripts
+        uses: actions/checkout@v2
+        with:
+          path: nightlies
+
+      - name: Cache build outputs
+        id: built
+        uses: actions/cache@v2
+        with:
+          path: output
+          key: >
+            output-${{ hashFiles('nightlies/build-release.sh') }}-${{ matrix.target.triple }}-${{ matrix.setting.commit }}
+
+      - name: Cache dependencies
+        if: steps.built.outputs.cache-hit != 'true'
+        uses: actions/cache@v2
+        with:
+          path: external
+          key: >
+            deps-${{ hashFiles('nightlies/deps.sh') }}-${{ hashFiles('nightlies/buildreq.txt') }}-${{ runner.os }}-${{ matrix.target.triple }}
+
+      - name: Install dependencies
+        if: steps.built.outputs.cache-hit != 'true'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: nightlies/deps.sh -t '${{ matrix.target.triple }}'
+
+      - name: Download generated source package
+        if: steps.built.outputs.cache-hit != 'true'
+        uses: actions/download-artifact@v2
+        with:
+          name: 'nim-${{ matrix.setting.commit }}'
+          path: source
+
+      - name: Extract source package
+        if: steps.built.outputs.cache-hit != 'true'
+        id: source
+        shell: bash
+        run: |
+          source=( source/nim-*.tar.xz )
+          version="${source[0]##*nim-}"
+          version="${version%.tar.xz}"
+          case '${{ runner.os }}' in
+            'Windows')
+              7z x -so "${source[0]}" | 7z x -si -ttar -aoa
+              ;;
+            *)
+              tar xJf "${source[0]}"
+              ;;
+          esac
+
+          echo "::set-output name=version::$version"
+
+      - name: Setup environment
+        if: steps.built.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          echo "-d:gitHash:\"${{ matrix.setting.commit }}\"" >> external/nim.cfg
+
+      - name: Build release binaries
+        if: steps.built.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          nightlies/build-release.sh 'nim-${{ steps.source.outputs.version }}'
+
+      - name: Prepare binaries for uploads
+        id: release
+        shell: bash
+        run: |
+          source nightlies/lib.sh
+
+          artifact=$(< output/nim.txt)
+          echo "::set-output name=artifact_name::$(basename "$artifact")"
+          if [[ '${{ needs.setup.outputs.deploy }}' != true ]]; then
+            # Github Actions work based on native Windows path, so we're doing
+            # some quick conversions here.
+            artifact=$(nativepath "$artifact")
+          fi
+          echo "::set-output name=artifact::$artifact"
+
+      - name: Upload release binaries
+        if: needs.setup.outputs.deploy == 'true'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd nightlies
+          if ! hub release show -f '%as' '${{ matrix.setting.release }}' | grep '${{ steps.release.outputs.artifact_name }}' >/dev/null 2>&1; then
+            hub release edit -m '' -a '${{ steps.release.outputs.artifact }}' '${{ matrix.setting.release }}'
+          else
+            echo "Binary already released for tag '${{ matrix.setting.release }}', not overwritting."
+          fi
+
+      - name: Upload binaries to artifacts
+        if: needs.setup.outputs.deploy != 'true'
+        uses: actions/upload-artifact@v2
+        with:
+          name: '${{ steps.release.outputs.artifact_name }}'
+          path: '${{ steps.release.outputs.artifact }}'

--- a/build-release.sh
+++ b/build-release.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+
+# Build release tarball/zip from a source package
+#
+# Copyright (c) 2020 Leorize <leorize+oss@disroot.org>
+#
+# This script is licensed under the MIT license.
+
+# shellcheck disable=SC2034
+_rev=1 # Bump this variable to force rebuild.
+       # This variable does not change the script behavior in anyway, but
+       # will trigger a cache mismatch for CI services configured to hash
+       # the script as part of the cache key.
+
+usage() {
+  cat << EOF
+Usage: $0 [-o folder] [-v version] <source>
+Build a binary Nim release from the specified source folder. This folder is
+assumed to be created from a standard Nim source archive.
+
+Options:
+    -o folder   Where to output the resulting artifacts. Defaults to $PWD/output.
+    -d folder   Where dependencies are downloaded into. Defaults to $PWD/external.
+    -h          This help message.
+
+Environment Variables:
+    CC          The compiler used to build csources.
+    CFLAGS      Flags to pass to C compilers when building C code.
+    LDFLAGS     Flags to pass to C compilers when linking C code.
+EOF
+}
+
+set -e
+set -o pipefail
+
+basedir=$(cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)
+# shellcheck source=lib.sh
+source "$basedir/lib.sh"
+
+output=$PWD/output
+outrel=$PWD
+deps=$PWD/external
+while getopts "o:v:d:h" curopt; do
+  case "$curopt" in
+    'o')
+      output=$(realpath "$OPTARG")
+      ;;
+    'd')
+      deps=$(realpath "$OPTARG")
+      ;;
+    'h')
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+shift $((OPTIND - 1))
+
+if [[ $# -lt 1 ]]; then
+  echo "$0: missing required argument -- <source>"
+  usage
+  exit 1
+fi
+
+if [[ -e $deps/environment ]]; then
+  echo "Sourcing dependencies environment"
+  # shellcheck source=/dev/null
+  source "$deps/environment"
+fi
+
+mkdir -p "$output"
+
+cd "$1"
+
+if [[ $(os) == darwin ]]; then
+  : "${CC:=clang}"
+else
+  : "${CC:=gcc}"
+fi
+
+export PATH=$PWD/bin${PATH:+:$PATH}
+
+TIMEFORMAT="Took %lR"
+
+cpu=$(arch_from_triple "$($CC -dumpmachine)")
+
+time {
+  fold "Build 1-stage csources compiler"
+  make "-j$(ncpu)" ucpu="$cpu" CC="$CC"
+  endfold
+}
+
+buildtmp=$PWD/build
+
+mkdir -p -- "$buildtmp/nim"
+
+export XDG_CONFIG_HOME=$buildtmp
+export XDG_CACHE_HOME=$buildtmp/nimcache
+
+rm -f "$buildtmp/nim/nim.cfg"
+
+if [[ -n "$CFLAGS" ]]; then
+  echo "passC%=\"\$CFLAGS\"" >> "$buildtmp/nim/nim.cfg"
+fi
+
+if [[ -n "$LDFLAGS" ]]; then
+  echo "passL%=\"\$LDFLAGS\"" >> "$buildtmp/nim/nim.cfg"
+fi
+
+if [[ -e $deps/nim.cfg ]]; then
+  echo "Importing configuration from $deps/nim.cfg"
+  cat "$deps/nim.cfg" >> "$buildtmp/nim/nim.cfg"
+fi
+
+time {
+  fold "Build koch"
+  nim c koch
+  endfold
+}
+
+time {
+  fold "Build compiler"
+  ./koch boot -d:release --skipUserCfg:off
+  endfold
+}
+
+eval "$(cat << EOF | nim secret --hints:off 2>/dev/null
+echo "version=", NimVersion
+echo "os=", hostOS
+quit 0
+EOF
+)"
+
+# Fail if the variables are not declared (ie. nim couldn't run)
+: "${version:?}" "${os:?}"
+
+cpusuffix=
+case "$cpu" in
+  i?86)
+    cpusuffix=_x32
+    ;;
+  x86_64)
+    cpusuffix=_x64
+    ;;
+  aarch64)
+    cpusuffix=_arm64
+    ;;
+  *)
+    cpusuffix=_$cpu
+    ;;
+esac
+
+suffix=-${os}$cpusuffix
+
+case "$os" in
+  windows)
+    time {
+      fold "Generate release"
+
+      mkdir -p web/upload/download
+
+      # Package DLLs
+      cp -t bin "$deps/dlls/"*.dll
+
+      nim c --outdir:. tools/winrelease
+      ./winrelease
+
+      artifact=$output/nim-${version}$suffix.zip
+      cp "web/upload/download/nim-${version}$cpusuffix.zip" "$artifact"
+
+      echo "Generated release artifact at $artifact"
+      echo "$artifact" > "$output/nim.txt"
+      endfold
+    }
+    ;;
+  *)
+    time {
+      fold "Build tools"
+      ./koch tools -d:release
+      endfold
+    }
+
+    major=${version%%.*}
+    minor=${version#*.}
+    minor=${minor%.*}
+    patch=${version##*.}
+    doc=(docs -d:release)
+    if [[ $major -ge 1 && $minor -ge 3 && $patch -ge 5 ]]; then
+      # Skip runnable examples and web docs build when supported. This speeds
+      # up the build by a huge margin, esp. on non-native archs.
+      doc=(--localdocs "${doc[@]}" --doccmd:skip)
+    fi
+    time {
+      fold "Build docs"
+      # Build release docs
+      ./koch "${doc[@]}"
+      endfold
+    }
+
+    time {
+      fold "Generate release"
+      # Cleanup build artifacts
+      # TODO: Rework niminst to be able to build binary archives for non-Windows
+      rm -rf "$buildtmp"
+      find . \
+        -mindepth 1 \
+        \( \
+          -name .git -prune -o \
+          -name c_code -prune -o \
+          -name nimcache -prune -o \
+          -name web -prune -o \
+          -name build.sh -o \
+          -name 'build*.bat' -o \
+          -name makefile -o \
+          -name '*.o' -o \
+          -path '*/compiler/nim' -o \
+          -path '*/compiler/nim?' \
+        \) \
+        -exec rm -rf '{}' +
+
+      cd ..
+
+      srcDir=$(basename "$1")
+      if [[ $srcDir != "nim-$version" ]]; then
+        # This is for people who build this locally...
+        ln -sf "$srcDir" "nim-$version"
+      fi
+
+      artifact=$output/nim-$version$suffix.tar
+      tar chf "$artifact" "nim-$version"
+      xz -9e "$artifact"
+      artifact=$artifact.xz
+
+      echo "Generated release artifact at $artifact"
+      echo "$artifact" > "$output/nim.txt"
+      endfold
+    }
+    ;;
+esac

--- a/buildreq.txt
+++ b/buildreq.txt
@@ -1,0 +1,3 @@
+SQLite-v3.31.1+0
+OpenSSL-v1.1.1+2
+PCRE-v8.42.0+2

--- a/bw-install.sh
+++ b/bw-install.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+
+# Simple JuliaBinaryWrappers downloader for use with nightlies CI
+#
+# Copyright (c) 2020 Leorize <leorize+oss@disroot.org>
+#
+# This script is licensed under the MIT license.
+
+usage() {
+  cat << EOF
+Usage: $0 [-o folder] [-t triple] <pkg>...
+Downloads and installs packages from JuliaBinaryWrappers.
+
+    <pkg>      The package specification, can be just the package name (ie.
+               SQLite, OpenSSL) to get the latest version, or a tag name for an
+               exact version (ie. SQLite-v3.31.1+0, OpenSSL-v1.1.1+2).
+
+Options:
+    -o folder  Where to install the specified packages to. If not specified the
+               current folder will be used.
+    -t triple  Specify the target triple for package downloads, if unspecified
+               will be automatically detected.
+    -h         This help message.
+EOF
+}
+
+detectTriple() {
+  case "$(uname -s)" in
+    Darwin)
+      if [[ $(uname -m) == x86_64 ]]; then
+        # Hardcode this triple due to later OSX uses never version sufficies
+        echo x86_64-apple-darwin14
+      else
+        echo Unsupported macOS version >&2
+        return 1
+      fi
+      ;;
+    *)
+      result=$(gcc -dumpmachine)
+      case "$result" in
+        *-linux-*)
+          result=${result/-pc/}
+          result=${result/-unknown/}
+          ;;
+      esac
+      echo "$result"
+      ;;
+  esac
+}
+
+getAsset() {
+  pkg=${1%%-*}_jll.jl
+  version=${1##*-}
+
+  queryLatest='
+query($repo: String!, $owner: String = "JuliaBinaryWrappers", $endCursor: String) {
+  repository(name: $repo, owner: $owner) {
+    releases(last: 1) {
+      nodes {
+        releaseAssets(first: 15, after: $endCursor) {
+          nodes {
+            ...assetFields
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+  }
+}
+'
+  getAssetsLatest='.data | .repository | .releases | .nodes[0] | .releaseAssets | .nodes[]'
+
+  queryExact='
+query($tag: String!, $repo: String!, $owner: String = "JuliaBinaryWrappers", $endCursor: String) {
+  repository(name: $repo, owner: $owner) {
+    release(tagName: $tag) {
+      releaseAssets(first: 15, after: $endCursor) {
+        nodes {
+          ...assetFields
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}
+'
+
+  getAssetsExact='.data | .repository | .release | .releaseAssets | .nodes[]'
+
+  assetFields='
+fragment assetFields on ReleaseAsset {
+  downloadUrl
+  name
+}
+'
+
+  declare -a hubParams
+
+  if [[ $1 == $version ]]; then
+    hubParams+=(-F "query=$queryLatest$assetFields" -F "repo=$pkg")
+    getAssets=$getAssetsLatest
+  else
+    hubParams+=(-F "query=$queryExact$assetFields" -F "repo=$pkg" -F "tag=$1")
+    getAssets=$getAssetsExact
+  fi
+
+  resp=$(hub api --paginate graphql "${hubParams[@]}") || exit 1
+
+  if [[ $(jq 'has("errors")' <<< "$resp") == true ]]; then
+    jq -r '.errors[] | .message' <<< "$resp" >&2
+    return 1
+  fi
+
+  if [[ -z "$triple" ]]; then
+    triple=$(detectTriple) || return 1
+  fi
+
+  jq -sr --arg triple "$triple" \
+    '[ .[] | '"$getAssets"' | select(.name | contains($triple)) ]' <<< "$resp"
+}
+
+output=$PWD
+triple=
+
+while getopts "o:t:h" curopt; do
+  case "$curopt" in
+    'o')
+      output=$OPTARG
+      ;;
+    't')
+      triple=$OPTARG
+      ;;
+    'h')
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+shift $((OPTIND - 1))
+
+if [[ $# -lt 1 ]]; then
+  echo "$0: missing required argument -- <pkg>"
+  usage
+  exit 1
+fi
+
+mkdir -p "$output" || exit 1
+cd "$output" || exit 1
+
+for pkg in "$@"; do
+  asset=$(getAsset "$pkg") || exit 1
+  case "$(jq 'length' <<< "$asset")" in
+    1)
+      ;;
+    0)
+      echo "Package $pkg not found for triple: $triple"
+      exit 1
+      ;;
+    *)
+      echo "Ambiguous triple '$triple'" >&2
+      exit 1
+      ;;
+  esac
+  asset=$(jq -r '.[0]' <<< "$asset")
+
+  url=$(jq -r '.downloadUrl' <<< "$asset") || exit 1
+  name=$(jq -r '.name' <<< "$asset") || exit 1
+  echo "Downloading $name ($url)"
+  curl -L "$url" -o "$name" || exit 1
+
+  echo "Installing $pkg"
+  tar xf "$name" || exit 1
+
+  echo "Cleaning artifact $name"
+  rm -f "$name" || exit 1
+done

--- a/deps.sh
+++ b/deps.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+
+# Install build dependencies for nightlies CI
+#
+# Copyright (c) 2020 Leorize <leorize+oss@disroot.org>
+#
+# This script is licensed under the MIT license.
+
+# NOTE: Editing this script will cause dependencies to be redownloaded
+
+# shellcheck disable=SC2034
+_rev=1 # Bump this variable if dependencies should be redownloaded.
+       # This variable does not change the script behavior in anyway, but
+       # will trigger a cache mismatch for CI services configured to hash
+       # the script as part of the cache key.
+
+usage() {
+  cat << EOF
+Usage: $0 [-o folder] [-t triple]
+Download build dependencies and configure environment for building nightlies.
+This script is designed for use with CI services. Tread carefully for local
+usage.
+
+Options:
+    -o folder  Where to download and install dependencies to. Defaults to
+               $PWD/external. If the folder already exists, it's assumed to
+               have been restored from a cache and configuration will take
+               place immediately.
+    -t triple  Specify the target triple for package downloads, if unspecified
+               will be automatically detected. On Linux/Windows this is used to
+               determine which toolchain should be downloaded.
+    -h         This help message.
+EOF
+}
+
+set -e
+set -o pipefail
+
+basedir=$(cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P)
+# shellcheck source=lib.sh
+source "$basedir/lib.sh"
+
+output=$PWD/external
+triple=$(gcc -dumpmachine)
+while getopts "o:t:a:h" curopt; do
+  case "$curopt" in
+    'o')
+      output=$(realpath "$OPTARG")
+      ;;
+    't')
+      triple=$OPTARG
+      ;;
+    'h')
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+shift $((OPTIND - 1))
+
+if [[ ! -d $output ]]; then
+  mkdir -p "$output"
+  cd "$output"
+
+  case "$(os)" in
+    windows)
+      arch=$(arch_from_triple "$triple")
+      case "$arch" in
+        i?86)
+          arch=32
+          ;;
+        x86_64)
+          arch=64
+          ;;
+        *)
+          error "unsupported target: $triple"
+          exit 1
+          ;;
+      esac
+      curl -L "https://nim-lang.org/download/mingw$arch-6.3.0.7z" -o "mingw$arch.7z"
+      curl -L "https://nim-lang.org/download/windeps.zip" -o "windeps.zip"
+      curl -L "https://nim-lang.org/download/dlls.zip" -o "dlls.zip"
+
+      7z x "mingw$arch.7z"
+      7z x -owindeps windeps.zip
+      7z x -odlls dlls.zip
+
+      rm -f "mingw$arch.7z" windeps.zip dlls.zip
+      ;;
+    linux)
+      # NOTE: This key is expired and it appears from the authors page that this
+      #       is intentional.
+      curl -L https://zv.io/BE4BF7E6811C5BA41345C11EB1D0B4566FBBDB40.asc | gpg --import
+
+      toolchain=$triple-native
+      toolchain_ver=9.3.0
+      curl -LO "https://more.musl.cc/$toolchain_ver/i686-linux-musl/$toolchain.tgz"
+      curl -LO "https://more.musl.cc/$toolchain_ver/i686-linux-musl/$toolchain.tgz.sig"
+
+      gpg --quiet --verify -- "$toolchain.tgz.sig"
+      tar xf "$toolchain.tgz"
+
+      xargs < "$basedir/buildreq.txt" "$basedir/bw-install.sh" -o "$toolchain" -t "$triple"
+      ;;
+    darwin)
+      xargs < "$basedir/buildreq.txt" "$basedir/bw-install.sh" -t "$triple"
+      ;;
+  esac
+else
+  cd "$output"
+  echo "Using cached dependencies"
+fi
+
+unset libdir
+rm -f nim.cfg
+rm -f environment
+cflags=()
+libs=()
+ldflags=()
+case "$(os)" in
+  windows)
+    pushpath mingw*/bin windeps dlls
+    ;;
+  linux | darwin)
+    if [[ $(os) == linux ]]; then
+      pushpath "$triple-native/bin"
+      libdir=$(realpath "$triple-native/lib")
+      ldflags+=(-static)
+      case "$(arch_from_triple "$triple")" in
+        i?86 | amd64)
+          ;; # Native
+        *)
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          ;;
+      esac
+
+      # Starting from musl 1.2.0, time_t is 64 bit on all arches
+      echo "-d:nimUse64BitCTime" >> nim.cfg
+    else
+      libdir=$(realpath lib)
+      cflags+=(-target "$triple")
+    fi
+    libs+=(libssl.a libcrypto.a libpcre.a libsqlite3.a)
+    ldflags+=("${libs[@]/#/$libdir/}")
+
+    cat <<EOF >> nim.cfg
+dynlibOverride="ssl"
+dynlibOverrideAll="on"
+EOF
+
+    pushenv LDFLAGS "${ldflags[*]}" CFLAGS "${cflags[*]}"
+    ;;
+esac

--- a/lib.sh
+++ b/lib.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+
+# Support library for tools
+
+## realpath [path]
+##
+## Poor man's substitute for the real realpath
+if ! command -v realpath >/dev/null 2>&1; then
+  realpath() {
+    python -c "import os; import sys; print(os.path.realpath(sys.argv[1]))" "$1"
+  }
+fi
+
+## is-var <varname>
+##
+## Check if a variable is set
+is-var() {
+  test -n "${!1+z}"
+}
+
+## error [message]..
+##
+## Pretty print error messages
+error() {
+  echo $'\e[31merror\e[m:' "${BASH_SOURCE[1]}(${BASH_LINENO[1]}) ${FUNCNAME[1]}:" "$@" >&2
+}
+
+## os
+##
+## Print the OS name in lower case.
+os() {
+  if [[ $OS == Windows_NT ]]; then
+    echo windows
+  else
+    uname | tr '[:upper:]' '[:lower:]'
+  fi
+}
+
+## arch_from_triple <triple>
+##
+## Print architecture from a target triplet.
+arch_from_triple() {
+  local triple=$1
+  echo "${triple%%-*}"
+}
+
+## ncpu
+##
+## Print number of logical CPUs, 1 is printed if couldn't be found
+ncpu() {
+  local ncpu=
+  case "$(os)" in
+    windows)
+      ncpu=$NUMBER_OF_PROCESSORS
+      ;;
+    darwin)
+      ncpu=$(sysctl -n hw.ncpu)
+      ;;
+    linux)
+      ncpu=$(nproc)
+      ;;
+  esac
+  if [[ $ncpu -le 0 ]]; then
+    ncpu=1
+  fi
+
+  echo "$ncpu"
+}
+
+## nativepath <path>
+##
+## Translate the given unix path to a native path.
+nativepath() {
+  if [[ $# -eq 0 ]]; then
+    error "a path must be given"
+    return 1
+  fi
+  if [[ -z "$1" ]]; then
+    error "path must not be empty"
+    return 1
+  fi
+  case "$(os)" in
+    windows)
+      sed -e 's|^/\(.\)|\1:|' -e 's|/|\\\\|g' <<< "$1"
+      ;;
+    *)
+      echo "$1"
+      ;;
+  esac
+}
+
+## pushenv (<variable name> [<value>])..
+##
+## Push the specified environment variable to be used with the next step in a
+## job pipeline.
+pushenv() {
+  if [[ $# -eq 0 ]]; then
+    error "a variable name must be passed"
+    return 1
+  fi
+
+  local printNotice=true
+  while [[ $# -gt 0 ]]; do
+    local name=$1
+    local value=$2
+
+    if [[ $value == *$'\n'* ]]; then
+      error "variable value must not contain newline"
+      return 1
+    fi
+    if is-var GITHUB_ACTIONS; then
+      echo "::set-env name=$name::$value"
+    else
+      if $printNotice; then
+        echo "Environmental settings are appended to $PWD/environment"
+        printNotice=false
+      fi
+      echo "export $name=${value@Q}" >> environment
+    fi
+
+    shift 2 || shift $#
+  done
+}
+
+## pushpath <path>..
+##
+## prepend the given values to PATH for the next step in a job pipeline.
+pushpath() {
+  if [[ $# -eq 0 ]]; then
+    error "a path must be passed"
+    return 1
+  fi
+
+  declare -a _pushpath_path
+  local snippet=false
+  while [[ $# -gt 0 ]]; do
+    if [[ -z "$1" ]]; then
+      error "path must not be empty"
+      return 1
+    fi
+    local path
+    path=$(realpath "$1")
+    if [[ $1 == *$'\n'* ]]; then
+      error "variable value must not contain newline"
+      return 1
+    fi
+    snippet=true
+    _pushpath_path=( "$path" "${_pushpath_path[@]}" )
+
+    shift 1
+  done
+
+  if $snippet; then
+    echo "Environmental settings are appended to $PWD/environment"
+    (IFS=': '; echo "export PATH=${_pushpath_path[*]@Q}\"\${PATH:+:\$PATH}\"") >> environment
+  fi
+}
+
+## fold [desc]..
+##
+## Start output fold with description `desc`
+fold() {
+  if is-var GITHUB_ACTIONS; then
+    echo "::group::$*"
+  fi
+}
+
+## endfold
+##
+## End the last output fold
+endfold() {
+  if is-var GITHUB_ACTIONS; then
+    echo "::endgroup::"
+  fi
+}


### PR DESCRIPTION
What's new:
- Parallel builds:

  With the move to Github Actions, we now have upto 20 jobs running
  concurrently. This reduce the total time needed for nightlies to be
  finished building. Additionally the binaries are released immediately
  as they're built, preventing the pipeline to be stalled by slow
  targets.

- Staged pipeline:

  This simplifies the workflow by separating them into individual
  environments. It also provides a better real-world representation of
  a distribution compiling Nim (building Nim from a pre-built source
  archive).

  The main selling point is that this allow for very flexible pipeline
  extensions. Currently we have these stages:
    - Generate build matrix
    - Generate Nim source tarball
    - Build release binaries from generated source

  It's trivial to share data between stages, so we can add features like
  testing the generated release further down in the road.

- Separation between development builds and nightlies:

  Changes to the pipeline will be built and published as artifacts
  instead of a release. This allows the pipeline to be tweaked upon
  and tested without having to wait for the next nightlies cycle, as
  well as enabling testing to be done without having the binaries
  released as a nightly. If a release is wanted, `[deploy]` can be added
  to the commit message to trigger a nightlies release immediately.

- Portable:

  The build scripts for generating binaries is independent from the
  workflow and can be executed on any machine. This enables offline
  development and allow the build setup to be carried across CI
  services.

- Fully self-contained binaries:

  The build system generates binaries that can be run on **any**
  system provided that they meet these basic requirements:

    - The architecture must be supported and built.
    - Either one of these:
      - Linux kernel >= 2.6
      - Windows 7 or newer (not verified, might support older versions)
      - macOS >= 10.10.0 (not verified, but this should be the oldest supported)

  The downside of this is that we have to drop support for:
    - ARMv6
    - Android
  due to the lack of prebuilt external dependency for them

- Semi-reproducible:

  The build environment is mostly fixed and can be reproduced using the
  build scripts. This allows the user to reproduce the generated
  binaries using the source tarball. However some environment settings
  are currently not exposed (ie. SOURCE_CODE_EPOCH) and no tests have
  been conducted to verify whether the reproducibility, though care have
  been taken to ensure this can be done.

PR in draft until nightlies run successfully, which can be monitored here: https://github.com/alaviss/nightlies/actions

Closes #33