### PR TITLE
workflows/nightlies: make use of environment file

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -181,7 +181,7 @@ jobs:
 
       - name: Setup environment
         shell: bash
-        run: echo '::add-path::${{ github.workspace }}/nim/bin'
+        run: echo '${{ github.workspace }}/nim/bin' >> "$GITHUB_PATH"
 
       - name: Build 1-stage csources compiler
         if: steps.nim-cache.outputs.cache-hit != 'true'

--- a/lib.sh
+++ b/lib.sh
@@ -103,19 +103,22 @@ pushenv() {
   while [[ $# -gt 0 ]]; do
     local name=$1
     local value=$2
+    local envfile=$PWD/environment
 
     if [[ $value == *$'\n'* ]]; then
       error "variable value must not contain newline"
       return 1
     fi
     if is-var GITHUB_ACTIONS; then
-      echo "::set-env name=$name::$value"
-    else
-      if $printNotice; then
-        echo "Environmental settings are appended to $PWD/environment"
-        printNotice=false
-      fi
-      echo "export $name=${value@Q}" >> environment
+      envfile=$GITHUB_ENV
+    fi
+    if ! echo "export $name=${value@Q}" >> "$envfile"; then
+      echo "Could not write environmental settings to $envfile"
+      return 1
+    fi
+    if $printNotice; then
+      echo "Environmental settings are appended to $envfile"
+      printNotice=false
     fi
 
     shift 2 || shift $#


### PR DESCRIPTION
The old add-path and set-env commands have been deprecated per
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/