### PR TITLE
nightlies: create latest-* aliases for released nightlies [deploy]

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -374,13 +374,10 @@ jobs:
           source nightlies/lib.sh
 
           artifact=$(< output/nim.txt)
-          echo "::set-output name=artifact_name::$(basename "$artifact")"
-          if [[ '${{ needs.setup.outputs.deploy }}' != true ]]; then
-            # Github Actions work based on native Windows path, so we're doing
-            # some quick conversions here.
-            artifact=$(nativepath "$artifact")
-          fi
           echo "::set-output name=artifact::$artifact"
+          # Github Actions work based on native Windows path, so we're doing
+          # some quick conversions here.
+          echo "::set-output name=artifact_nativepath::$(nativepath "$artifact")"
 
       - name: Upload release binaries
         if: needs.setup.outputs.deploy == 'true'
@@ -396,8 +393,59 @@ jobs:
           fi
 
       - name: Upload binaries to artifacts
-        if: needs.setup.outputs.deploy != 'true'
         uses: actions/upload-artifact@v2
         with:
-          name: '${{ steps.release.outputs.artifact_name }}'
-          path: '${{ steps.release.outputs.artifact }}'
+          name: 'binaries-${{ matrix.setting.branch }}-${{ matrix.setting.commit }}'
+          path: '${{ steps.release.outputs.artifact_nativepath }}'
+
+  latestTag:
+    needs: [ setup, build ]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        setting: ${{ fromJson(needs.setup.outputs.settings) }}
+
+    if: needs.setup.outputs.deploy == 'true'
+    name: 'Update latest tags for ${{ matrix.setting.release }}'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout nightlies
+        uses: actions/checkout@v2
+        with:
+          path: nightlies
+
+      - name: Download built binaries from artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: 'binaries-${{ matrix.setting.branch }}-${{ matrix.setting.commit }}'
+          path: binaries
+
+      - name: 'Push latest-${{ matrix.setting.branch }} tag'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag='latest-${{ matrix.setting.branch }}'
+          aliasFor='${{ matrix.setting.release }}'
+          echo "Deleting release $tag"
+          hub -C nightlies release delete $tag || :
+
+          echo "Create $tag as draft"
+          cat << EOF | hub -C nightlies release create -d -F - "$tag" >/dev/null
+          Latest successful build for branch ${{ matrix.setting.branch }}
+
+          This release is an alias for the latest successful nightly build \
+          for branch \`${{ matrix.setting.branch }}\`: https://github.com/${{ github.repository }}/releases/tag/${{ matrix.setting.release }}
+
+          Each \`latest-\` alias is guaranteed to contain binaries for all \
+          supported architectures.
+          EOF
+
+          for artifact in binaries/*; do
+            echo "Uploading $artifact"
+            hub -C nightlies release edit -m '' -a "$artifact" "$tag"
+          done
+
+          echo "Publishing $tag"
+          hub -C nightlies release edit -m '' --draft=false "$tag"


### PR DESCRIPTION
With this commit, the nightlies generated by the workflow will be tagged with `latest-<branch name>`, and only if the nightly build was successful. This enables users to easily get the latest binaries with a fixed url (do expect 404 when those binaries are being updated though, but that shouldn't last for more than 10s).

Fixes #31.

Draft for now as I'm not a fan of how this is currently triggered, I'll need to add a few more safeguards just to be sure, but you can see it working here: https://github.com/alaviss/nightlies/releases