### PR TITLE
nightlies: new features for the latest- tags [deploy]

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -444,7 +444,8 @@ jobs:
           tag='latest-${{ matrix.setting.branch }}'
           aliasFor='${{ matrix.setting.release }}'
           echo "Deleting release $tag"
-          hub -C nightlies release delete $tag || :
+          hub -C nightlies release delete "$tag" || :
+          git -C nightlies push --delete origin "$tag" || :
 
           echo "Create $tag as draft"
           cat << EOF | hub -C nightlies release create -d -F - "$tag" >/dev/null

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -465,12 +465,16 @@ jobs:
           EOF
 
           source=(source/*)
-          echo "Uploading ${source[0]}"
-          hub -C nightlies release edit -m '' -a "${source[0]}" "$tag"
+          mv -v "${source[0]}" "source/source.tar.xz"
+          echo "Uploading ${source[0]} as source.tar.xz"
+          hub -C nightlies release edit -m '' -a "source/source.tar.xz" "$tag"
 
           for artifact in binaries/*; do
-            echo "Uploading $artifact"
-            hub -C nightlies release edit -m '' -a "$artifact" "$tag"
+            # Trim version from artifact name
+            shortName=${artifact#*nim-*-*-}
+            mv -v "$artifact" "binaries/$shortName"
+            echo "Uploading $artifact as $shortName"
+            hub -C nightlies release edit -m '' -a "binaries/$shortName" "$tag"
           done
 
           echo "Publishing $tag"

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -430,6 +430,12 @@ jobs:
         with:
           path: nightlies
 
+      - name: Download generated source package
+        uses: actions/download-artifact@v2
+        with:
+          name: 'nim-${{ matrix.setting.commit }}'
+          path: source
+
       - name: Download built binaries from artifacts
         uses: actions/download-artifact@v2
         with:
@@ -457,6 +463,10 @@ jobs:
           Each \`latest-\` alias is guaranteed to contain binaries for all \
           supported architectures.
           EOF
+
+          source=(source/*)
+          echo "Uploading ${source[0]}"
+          hub -C nightlies release edit -m '' -a "${source[0]}" "$tag"
 
           for artifact in binaries/*; do
             echo "Uploading $artifact"


### PR DESCRIPTION
Changes:
- The `latest-` tags will now be re-created on every deployment build. This refreshes the release history so that the release will always be on top (hopefully).
- The source tarball is also uploaded.
- Binary and sources uploaded to `latest-` tag will now have `nim-$version` trimmed. This make it so that automated tool can enjoy a constant link to the newest build whenever it's available.

Ref https://github.com/nim-lang/nightlies/issues/31#issuecomment-707415379

/cc @genotrance for opinion on whether this behavior is desirable.