### PR TITLE
build-release: parse version using regex

### DIFF
--- a/build-release.sh
+++ b/build-release.sh
@@ -128,12 +128,11 @@ time {
   endfold
 }
 
-eval "$(cat << EOF | nim secret --hints:off 2>/dev/null
-echo "version=", NimVersion
-echo "os=", hostOS
-quit 0
-EOF
-)"
+versionRegex='^Nim Compiler Version ([0-9]+\.[0-9]+\.[0-9]+) \[([a-zA-Z0-9]+): [a-zA-Z0-9]+\]'
+if [[ $(nim --version 2>&1) =~ $versionRegex ]]; then
+  version=${BASH_REMATCH[1]}
+  os=${BASH_REMATCH[2],,}
+fi
 
 # Fail if the variables are not declared (ie. nim couldn't run)
 : "${version:?}" "${os:?}"

--- a/build-release.sh
+++ b/build-release.sh
@@ -131,7 +131,7 @@ time {
 versionRegex='^Nim Compiler Version ([0-9]+\.[0-9]+\.[0-9]+) \[([a-zA-Z0-9]+): [a-zA-Z0-9]+\]'
 if [[ $(nim --version 2>&1) =~ $versionRegex ]]; then
   version=${BASH_REMATCH[1]}
-  os=${BASH_REMATCH[2],,}
+  os=$(tolowercase "${BASH_REMATCH[2]}")
 fi
 
 # Fail if the variables are not declared (ie. nim couldn't run)

--- a/lib.sh
+++ b/lib.sh
@@ -198,3 +198,12 @@ endfold() {
     echo "::endgroup::"
   fi
 }
+
+## tolowercase <string>
+##
+## Convert string to lower case because CI bash
+## might not support the built-in case changing
+## parameter expansion
+tolowercase() {
+  echo "$(tr [A-Z] [a-z] <<< "${1?}")"
+}


### PR DESCRIPTION
While `nim secret` was useful for obtaining this information
programmatically, its output appears to not be as stable as expected.

This commit change build-release to use bash regex capability to obtain
the needed information from `nim --version`.

Fixes broken `devel` nightlies.