### PR TITLE
deps: update revision to trigger redownload of windeps

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -9,7 +9,7 @@
 # NOTE: Editing this script will cause dependencies to be redownloaded
 
 # shellcheck disable=SC2034
-_rev=1 # Bump this variable if dependencies should be redownloaded.
+_rev=2 # Bump this variable if dependencies should be redownloaded.
        # This variable does not change the script behavior in anyway, but
        # will trigger a cache mismatch for CI services configured to hash
        # the script as part of the cache key.


### PR DESCRIPTION
On 09 Feb 2021 10:37:48 GMT, windeps.zip was updated to introduce a
certificate store.

This commit bumps the revision so that nightlies downloads this update.

/cc @narimiran as a reminder to invalidate the cache whenever there is an update to windeps.
/cc @Araq we should version windeps so it'd be easier to track with nightlies. If you can tell me how you assembled the entire thing, I can automate and open source it so that everyone can see what's changed between updates.