### PR TITLE
nightlies: print out external directory

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -350,6 +350,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: nightlies/deps.sh -t '${{ matrix.target.triple }}'
 
+      - name: debug: list deps
+        shell: bash
+        run: ls -lR external
+
       - name: Download generated source package
         if: steps.built.outputs.cache-hit != 'true'
         uses: actions/download-artifact@v2


### PR DESCRIPTION
From the build output of 5dc544e1f521e94874c22ee5209d38460b968243,
windeps.zip should have been redownloaded, but it appears that this
might not be the case.

Add a step to print out the `external` folder so that we can confirm the
contents.

This is not to be merged.