### PR TITLE
trigger deploy on `workflow_dispatch`

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           deploy=false
           case '${{ github.event_name }}' in
-            schedule)
+            schedule | workflow_dispatch)
               deploy=true
               ;;
             push)


### PR DESCRIPTION
Before this PR, only scheduled CI is deployed or PRs with [deploy] in the title