### PR TITLE
disable aarch64 linux musl target

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -316,8 +316,8 @@ jobs:
             triple: x86_64-linux-musl
           - os: linux
             triple: i686-linux-musl
-          - os: linux
-            triple: aarch64-linux-musl
+          #- os: linux
+          #  triple: aarch64-linux-musl
           - os: linux
             triple: armv7l-linux-musleabihf
           - os: macosx


### PR DESCRIPTION
Has been broken since February 26 (seemingly unrelated to #104 which was a PR on the same day) occasionally along with other versions due to a gcc segfault, this has prevented nightly builds from creating releases since.