### PR TITLE
fixes #109 by using arm64 linux runner

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -316,8 +316,8 @@ jobs:
             triple: x86_64-linux-musl
           - os: linux
             triple: i686-linux-musl
-          #- os: linux
-          #  triple: aarch64-linux-musl
+          - os: linux_arm64
+            triple: aarch64-linux-musl
           - os: linux
             triple: armv7l-linux-musleabihf
           - os: macosx
@@ -341,6 +341,9 @@ jobs:
           - target:
               os: macosx_arm64
             builder: macos-15
+          - target:
+              os: linux_arm64
+            builder: ubuntu-22.04-arm
 
     env: ${{ matrix.setting.environment }}
     name: '${{ matrix.target.triple }} (${{ matrix.setting.branch }}, ${{ matrix.setting.commit }})'

--- a/deps.sh
+++ b/deps.sh
@@ -130,7 +130,7 @@ case "$(os)" in
       libdir=$(realpath "$triple-native/lib")
       ldflags+=(-static)
       case "$(arch_from_triple "$triple")" in
-        i?86 | amd64)
+        i?86 | amd64 | aarch64)
           ;; # Native
         *)
           docker run --rm --privileged multiarch/qemu-user-static --reset -p yes


### PR DESCRIPTION
fixes https://github.com/nim-lang/nightlies/issues/109.

According to https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories ,
> The arm64 Linux and Windows runners are in public preview and subject to change.